### PR TITLE
商品検索機能の修正、ルーティング変更、バリデーションの追加

### DIFF
--- a/src/php/app/Http/Controllers/ItemsController.php
+++ b/src/php/app/Http/Controllers/ItemsController.php
@@ -1,13 +1,14 @@
 <?php
 
 namespace App\Http\Controllers;
+
 use App\Models\Item;
 use App\Models\Topping;
 use Illuminate\Http\Request;
 
 class ItemsController extends Controller
 {
-     /**
+    /**
      *商品一覧画面（ホーム画面）を表示するメソッド
      *
      *eroquentのallメソッドでItemsテーブルから全商品データを取得し変数$itemに格納したのちにviewに引き渡す。
@@ -17,58 +18,79 @@ class ItemsController extends Controller
      * @return 商品一覧画面
      */
 
-     public function showItems(Request $request)
-     {
-            $query = Item::query();
-         
-    //キーワード検索機能の実装
-            if ($request->filled('keyword')) {
-                $keyword = '%' . $this->escape($request->input('keyword')) . '%';
-                $query->where(function ($query) use ($keyword) {
-                    $query->where('name', 'LIKE', $keyword);
-                    $query->orWhere('description', 'LIKE', $keyword);
-                });
-            }
-        
-            $items = $query->orderBy('price_m', 'asc')
+    public function showItems(Request $request)
+    {
+
+        $query = Item::query();
+
+
+        $items = $query->orderBy('price_m', 'asc')
+            ->paginate(4);
+
+        return view('items.item_list')
+            ->with('items', $items);
+    }
+
+
+    /**
+     * キーワード検索機能のためのエスケープ処理
+     *
+     * @param string $value 入力されたキーワード
+     * @return エスケープ処理後のキーワード
+     */
+    private function escape(string $value)
+    {
+        return str_replace(
+            ['\\', '%', '_'],
+            ['\\\\', '\\%', '\\_'],
+            $value
+        );
+    }
+
+    public function searchItems(Request $request)
+    {
+
+        $query = Item::query();
+
+        $validated = $request->validate([
+            'keyword' => 'required|max:100',
+        ],
+        [
+            'keyword.required' => 'キーワードは必須です。',
+            'keyword.max' => 'キーワードは最大100文字です',
+     ]);
+
+
+        //キーワード検索機能の実装
+        if ($request->filled('keyword')) {
+            $keyword = '%' . $this->escape($request->input('keyword')) . '%';
+            $query->where(function ($query) use ($keyword) {
+                $query->where('name', 'LIKE', $keyword);
+                $query->orWhere('description', 'LIKE', $keyword);
+            });
+        }
+
+        $items = $query->orderBy('price_m', 'asc')
             ->paginate(5);
 
-            return view('items.item_list')
+        return view('items.item_list')
             ->with('items', $items);
-   }
+    }
 
-   
-   /**
-    * キーワード検索機能のためのエスケープ処理
-    *
-    * @param string $value 入力されたキーワード
-    * @return エスケープ処理後のキーワード
-    */
-   private function escape(string $value)
-   {
-       return str_replace(
-           ['\\', '%', '_'],
-           ['\\\\', '\\%', '\\_'],
-           $value
-       );
-   }
-
-
- /**
- * 商品詳細画面を表示するメソッド
- *
- * @param Item $item  ルートモデルバインディングでurlで指定されたidに対応したitemオブジェクトと自動取得
- * @return 商品詳細画面
- */
+    /**
+     * 商品詳細画面を表示するメソッド
+     *
+     * @param Item $item  ルートモデルバインディングでurlで指定されたidに対応したitemオブジェクトと自動取得
+     * @return 商品詳細画面
+     */
     public function showItemDetail(Item $item)
     {
-       $toppings = Topping::all();
+        $toppings = Topping::all();
 
-       return view('items.item_detail')
+        return view('items.item_detail')
             ->with([
-               'item' => $item,
-               'toppings' => $toppings,
-           ]);
+                'item' => $item,
+                'toppings' => $toppings,
+            ]);
     }
 }
-

--- a/src/php/app/Http/Kernel.php
+++ b/src/php/app/Http/Kernel.php
@@ -35,7 +35,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \App\Http\Middleware\CartSession::class,
+            //\App\Http\Middleware\CartSession::class,
         ],
 
         'api' => [

--- a/src/php/resources/views/items/item_list.blade.php
+++ b/src/php/resources/views/items/item_list.blade.php
@@ -7,16 +7,25 @@
 @section('content')
 <div class="row">
   <div class="col-lg-offset-3 col-lg-6 col-md-offset-2 col-md-8 col-sm-10 col-xs-12">
+    @if ($errors->any())
+    <div class="alert alert-danger">
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+    @endif
     <div class="panel panel-default">
-      <div class="panel-heading">
+    <div class="panel-heading">
         <div class="panel-title">商品を検索する</div>
       </div>
       <div class="panel-body">
 
-        <form method="post" action="/" class="form-horizontal">
+        <form  action="/search" class="form-horizontal" >
           @csrf
           <div class="form-group">
-            <label for="code" class="control-label col-sm-2">商品名</label>
+            <label for="code" class="control-label col-sm-2">キーワード</label>
             <div class="col-sm-9">
               <input type="text" name="keyword" id="keyword" class="form-control input-sm" />
             </div>
@@ -51,7 +60,7 @@
           @endforeach
         </tr>
       </tbody>
-    </table>
+     </table>
     <!-- ページングボタン -->
     <div class="text-center">
       {{ $items->withQueryString()->links() }}

--- a/src/php/routes/web.php
+++ b/src/php/routes/web.php
@@ -19,7 +19,7 @@ use App\Http\Controllers\OrderController;
 Auth::routes();
 Route::get('/', [ItemsController::class, 'showItems'])->name('top');
 
-Route::get('/search', [ItemsController::class, 'showItems'])->name('search');
+Route::get('/search', [ItemsController::class, 'searchItems'])->name('search');
 Route::get('/item/{item}', [ItemsController::class, 'showItemDetail'])->name('item');
 
 Route::get('/cart', [CartController::class, 'showCartItems'])->name('cart');


### PR DESCRIPTION
## 概要

> 商品検索機能のルーティングを設計通りに変更
>検索フォームに必須入力、最大文字数１００文字のバリエーションをitemsコントローラーに追加
>商品一覧画面での表示される商品数を４つに変更

## 観点

>ルーティングは設計通りか
>バリデーション機能は十分か

## テスト

> 自端末で動作確認済み

## 関連する Issue

> 関連する Issue へのリンク。
