### PR TITLE
クーポン適用後の価格がpay.jpとメールに反映されないバグを修正

### DIFF
--- a/src/php/app/Http/Controllers/BaseController.php
+++ b/src/php/app/Http/Controllers/BaseController.php
@@ -35,7 +35,6 @@ class BaseController extends Controller
         $tax = (int)Cart::calculateTax($total_price); // 消費税を計算
         $total_price += $tax; // 消費税を合計金額に上乗せ
 
-
         // return view('cart.cart_list', [
         //     'items' => $items,
         //     'toppings' => $toppings,
@@ -46,6 +45,32 @@ class BaseController extends Controller
         $cart = Cart::where('user_id', Auth::user()->id)->first();
         $cart->total_price = $total_price;
         $cart->save();
+
+        return [
+            'items' => $items,
+            'toppings' => $toppings,
+            'total_price' => $total_price,
+            'tax' => $tax,
+        ];
+    }
+
+
+     public function onlyCouponAdaptionGetCartItems(){
+
+        // セッションからカート情報を取得する
+        $cart_id = Session::get('cart');
+        $toppings = null;
+
+        // カートの中からセッションの情報に入っているcart_idを持つCartItemテーブルを取得
+        $items = CartItem::where('cart_id', $cart_id)->get();
+        if (count($items) > 0) {
+            $toppings = CartTopping::where('cart_item_id', $items->first()->id)->get();
+        }
+
+        $total_price = (int)Cart::calculateTotalPrice($items, $toppings); // 合計金額を計算
+        $tax = (int)Cart::calculateTax($total_price); // 消費税を計算
+        $total_price += $tax; // 消費税を合計金額に上乗せ
+
 
         return [
             'items' => $items,
@@ -76,4 +101,7 @@ class BaseController extends Controller
         // カート画面にリダイレクト
         return redirect(route('cart'));
     }
+
+
+
 }


### PR DESCRIPTION
## 概要

> 注文確認画面で配送先情報自動取得ボタンを押した際に呼ばれるメソッドに、cartテーブルのtotal_priceカラムが書き換える処理があったため、total_priceを書き換える処理を省いたonlyCouponAdaptionGetCartItemsメソッドをbaseコントローラーに定義して対処

## 観点

>baseコントローラーにonlyCouponAdaptionGetCartItems()を定義した点。
> 住所自動取得ボタンで呼ばれるpublic function showDeliveryForm()から呼び出されるメソッドをonlyCouponAdaptionGetCartItems()に変更した点

## テスト

> 自端末で動作確認済み

## 関連する Issue

> 関連する Issue へのリンク。
